### PR TITLE
fix(deps): update pymbrewclient requirement to version 1.8.0

### DIFF
--- a/custom_components/minibrew/manifest.json
+++ b/custom_components/minibrew/manifest.json
@@ -11,7 +11,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/stuartp44/hambrewclient/issues",
   "requirements": [
-    "pymbrewclient>=1.0.10"
+    "pymbrewclient>=1.8.0"
   ],
   "version": "0.7.1"
 }


### PR DESCRIPTION
This pull request updates the dependency version for `pymbrewclient` in the `manifest.json` file to ensure compatibility with newer features or bug fixes.

Dependency update:

* Increased the minimum required version of `pymbrewclient` from `1.0.10` to `1.8.0` in `custom_components/minibrew/manifest.json`