### PR TITLE
fix: enhance device handling in MiniBrew sensor integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Handle Device objects returned by the API without setup errors
+
 ### Added
 - Initial release of MiniBrew Home Assistant integration
 - Support for MiniBrew Craft devices

--- a/custom_components/minibrew/sensor.py
+++ b/custom_components/minibrew/sensor.py
@@ -1,13 +1,27 @@
 import logging
+from dataclasses import asdict, is_dataclass
+from datetime import timedelta
+
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from pymbrewclient import BreweryOverview, Device
-from datetime import timedelta
 
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _device_to_dict(device):
+    if isinstance(device, dict):
+        return device
+    if isinstance(device, Device):
+        if is_dataclass(device):
+            return asdict(device)
+        return device.__dict__
+    if hasattr(device, "__dict__"):
+        return device.__dict__
+    return {}
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up MiniBrew sensors from a config entry."""
@@ -26,12 +40,16 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     def add_new_sensors():
         for state, devices in coordinator.data.__dict__.items():  # Access states dynamically
             for device_data in devices:
+                device_dict = _device_to_dict(device_data)
+                serial_number = device_dict.get("serial_number")
+                if not serial_number:
+                    continue
                 # Check if the device has already been added
-                if device_data["serial_number"] in added_devices:
+                if serial_number in added_devices:
                     continue
 
                 # Convert the raw dictionary to a Device object
-                device = Device(**device_data)
+                device = device_data if isinstance(device_data, Device) else Device(**device_dict)
 
                 # Add sensors for MiniBrew devices
                 if device.device_type == 0:  # Craft device
@@ -54,7 +72,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     sensors.append(KegNeedsCleaningSensor(coordinator, device, state))
                     sensors.append(KegActionRequiredSensor(coordinator, device, state))
                 # Mark the device as added
-                added_devices.add(device_data["serial_number"])
+                added_devices.add(serial_number)
 
     # Add initial sensors
     add_new_sensors()
@@ -139,8 +157,9 @@ class CraftSensor(SensorEntity):
         """Get the latest device data from the coordinator."""
         devices = getattr(self.coordinator.data, self.device_type, [])
         for dev in devices:
-            if dev["serial_number"] == self.device_id:
-                return dev
+            device_dict = _device_to_dict(dev)
+            if device_dict.get("serial_number") == self.device_id:
+                return device_dict
         return None
 
 class CraftSensorBrewStageSensor(CraftSensor):
@@ -372,7 +391,8 @@ class CraftSensorCurrentStageSensor(CraftSensor):
         """Return a human-readable phase name based on the device's group."""
         for group_name, devices in self.coordinator.data.__dict__.items():
             for dev in devices:
-                if dev.get("serial_number") == self.device_id:
+                device_dict = _device_to_dict(dev)
+                if device_dict.get("serial_number") == self.device_id:
                     return group_name
 
         return "unknown"
@@ -500,8 +520,9 @@ class KegSensor(SensorEntity):
         """Get the latest device data from the coordinator."""
         devices = getattr(self.coordinator.data, self.device_type, [])
         for dev in devices:
-            if dev["serial_number"] == self.device_id:
-                return dev
+            device_dict = _device_to_dict(dev)
+            if device_dict.get("serial_number") == self.device_id:
+                return device_dict
         return None
 
 class KegCurrentTemperatureSensor(KegSensor):


### PR DESCRIPTION
This pull request addresses issues with handling `Device` objects returned by the API in the MiniBrew Home Assistant integration, ensuring that both dictionary and object representations are processed correctly. The main changes improve robustness and compatibility when interacting with device data, preventing errors when the API returns `Device` instances instead of dictionaries.

**Device data handling improvements:**

* Added the `_device_to_dict` helper function in `sensor.py` to consistently convert `Device` objects or other representations into dictionaries for reliable attribute access.
* Updated all locations in `sensor.py` where device data is accessed (e.g., when checking the `serial_number`) to use `_device_to_dict`, ensuring compatibility with both dicts and `Device` objects. [[1]](diffhunk://#diff-ae7524ce24946f2428a9c737445f023efce0747a0bb024a7ff49536a8108887dR43-R52) [[2]](diffhunk://#diff-ae7524ce24946f2428a9c737445f023efce0747a0bb024a7ff49536a8108887dL57-R75) [[3]](diffhunk://#diff-ae7524ce24946f2428a9c737445f023efce0747a0bb024a7ff49536a8108887dL142-R162) [[4]](diffhunk://#diff-ae7524ce24946f2428a9c737445f023efce0747a0bb024a7ff49536a8108887dL375-R395) [[5]](diffhunk://#diff-ae7524ce24946f2428a9c737445f023efce0747a0bb024a7ff49536a8108887dL503-R525)

**Bug fix:**

* Fixed an issue where the integration would fail if the API returned `Device` objects without setup errors, as noted in the changelog.
