### PR TITLE
feat: add beer name sensor to Keg device integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This integration allows you to monitor and control your MiniBrew brewing devices
 ### Keg Device Sensors
 - **Current Temperature** - Real-time keg temperature
 - **Target Temperature** - Configured serving temperature
+- **Beer Name** - Currently loaded beer name
 - **Beer Style** - Currently loaded beer style
 - **Online Status** - Device connectivity status
 - **Is Updating** - Firmware update status

--- a/custom_components/minibrew/manifest.json
+++ b/custom_components/minibrew/manifest.json
@@ -11,7 +11,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/stuartp44/hambrewclient/issues",
   "requirements": [
-    "pymbrewclient>=1.8.0"
+    "pymbrewclient>=1.8.1"
   ],
   "version": "0.7.3"
 }

--- a/custom_components/minibrew/sensor.py
+++ b/custom_components/minibrew/sensor.py
@@ -67,6 +67,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     sensors.append(KegCurrentTemperatureSensor(coordinator, device, state))
                     sensors.append(KegTargetTemperatureSensor(coordinator, device, state))
                     sensors.append(KegBeerStyleSensor(coordinator, device, state))
+                    sensors.append(KegBeerNameSensor(coordinator, device, state))
                     sensors.append(KegOnlineStatusSensor(coordinator, device, state))
                     sensors.append(KegIsUpdatingSensor(coordinator, device, state))
                     sensors.append(KegNeedsCleaningSensor(coordinator, device, state))

--- a/custom_components/minibrew/sensor.py
+++ b/custom_components/minibrew/sensor.py
@@ -627,6 +627,11 @@ class KegBeerStyleSensor(KegSensor):
         return device.get("beer_style") if device else None
 
     @property
+    def icon(self):
+        """Return the icon for the sensor."""
+        return "mdi:beer"
+
+    @property
     def unique_id(self):
         """Return the unique ID of the sensor."""
         return f"{self.device_id}_{self.name}"

--- a/custom_components/minibrew/sensor.py
+++ b/custom_components/minibrew/sensor.py
@@ -38,12 +38,18 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     
     # Function to add new sensors dynamically
     def add_new_sensors():
+        # Track devices currently in the API response
+        current_devices = set()
+        
         for state, devices in coordinator.data.__dict__.items():  # Access states dynamically
             for device_data in devices:
                 device_dict = _device_to_dict(device_data)
                 serial_number = device_dict.get("serial_number")
                 if not serial_number:
                     continue
+                
+                current_devices.add(serial_number)
+                
                 # Check if the device has already been added
                 if serial_number in added_devices:
                     continue
@@ -74,6 +80,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     sensors.append(KegActionRequiredSensor(coordinator, device, state))
                 # Mark the device as added
                 added_devices.add(serial_number)
+        
+        # Remove devices that are no longer in the API response
+        # This allows offline/reconnecting devices to be re-registered
+        added_devices.intersection_update(current_devices)
 
     # Add initial sensors
     add_new_sensors()


### PR DESCRIPTION
This pull request updates the MiniBrew integration by adding a new sensor for the keg's beer name, improves dynamic device tracking, and bumps the `pymbrewclient` dependency version. The main changes are grouped below:

**New Sensor Feature:**

* Added a `KegBeerNameSensor` to track and expose the name of the currently loaded beer in each keg. This includes updating the sensor registration logic and documentation. [[1]](diffhunk://#diff-ae7524ce24946f2428a9c737445f023efce0747a0bb024a7ff49536a8108887dR76-R87) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R29)

**Device Tracking Improvements:**

* Enhanced the logic in `add_new_sensors()` to track which devices are currently present in the API response, allowing for more robust handling of devices that go offline and come back online. Devices no longer present are removed from the tracked set, supporting re-registration. [[1]](diffhunk://#diff-ae7524ce24946f2428a9c737445f023efce0747a0bb024a7ff49536a8108887dR41-R52) [[2]](diffhunk://#diff-ae7524ce24946f2428a9c737445f023efce0747a0bb024a7ff49536a8108887dR76-R87)

**Dependency Update:**

* Updated the `pymbrewclient` requirement to version `>=1.8.1` to ensure compatibility with the new features.
